### PR TITLE
separate image upload from qr scan, disable camera when window is not focused

### DIFF
--- a/client/src/polymon-app/polymon-app.html
+++ b/client/src/polymon-app/polymon-app.html
@@ -263,6 +263,11 @@
         notifications="{{notifications}}">
     </polymon-notification-overlay>
 
+    <polymon-notification-overlay
+        id="clientNotificationOverlay"
+        notifications="{{clientNotifications}}">
+    </polymon-notification-overlay>
+
     <polymon-music
         id="music"
         playing="{{musicPlaying}}"
@@ -301,12 +306,21 @@
 
         musicPlaying: {
           type: Boolean
+        },
+
+        clientNotifications: {
+          type: Array,
+          value: function() {
+            return [];
+          }
         }
       },
 
       listeners: {
         'polymon-code': '__onPolymonCode',
-        'polydex-entry-added': '__onPolydexEntryAdded'
+        'polydex-entry-added': '__onPolydexEntryAdded',
+        'polymon-show-notification': '__onShowNotification',
+        'polymon-hide-notification': '__onHideNotification'
       },
 
       observers: [
@@ -463,6 +477,36 @@
             window.ga('send', 'pageview', this.route.path);
           }
         });
+      },
+
+      __onShowNotification: function(event) {
+        const i = this.__getIndexOfClientNotification(event.detail.notificationId);
+        console.log('show notification', i);
+        event.detail.acknowledged = false;
+        if (i > -1) {
+          this.set(`clientNotifications.${i}`, event.detail);
+        } else {
+          this.push('clientNotifications', event.detail);
+        }
+      },
+
+      __onHideNotification: function(event) {
+        const i = this.__getIndexOfClientNotification(event.detail.notificationId);
+        console.log('hide notification', i);
+        if (i > -1) {
+          this.set(`clientNotifications.${i}.acknowledged`, true);
+        }
+      },
+
+      __getIndexOfClientNotification: function(notificationId) {
+        if (this.clientNotifications.length && notificationId) {
+          for (let i = 0; i < this.clientNotifications.length; i++) {
+            if (this.clientNotifications[i].notificationId === notificationId) {
+              return i;
+            }
+          }
+        }
+        return -1;
       }
     });
   </script>

--- a/client/src/polymon-app/polymon-notification-overlay.html
+++ b/client/src/polymon-app/polymon-notification-overlay.html
@@ -7,7 +7,8 @@
   <template>
     <template is="dom-repeat" items="{{notifications}}" as="notification">
       <polymon-notification
-          notification="{{notification}}"
+          message="[[notification.message]]"
+          type="[[notification.type]]"
           active="[[__identical(notification, activeNotification)]]">
       </polymon-notification>
     </template>
@@ -52,6 +53,11 @@
         }
 
         this.activeNotification = activeNotification || null;
+      },
+
+      __onAcknowledged: function() {
+        const i = this.notifications.indexOf(this.activeNotification);
+        this.set(`notifications.${i}.acknowledged`, true);
       }
     });
   </script>

--- a/client/src/polymon-app/polymon-notification.html
+++ b/client/src/polymon-app/polymon-notification.html
@@ -73,7 +73,7 @@
         box-shadow: 0px 1px 0px #8C0300;
       }
     </style>
-    <span id="content">[[notification.message]]</span>
+    <span id="content">[[message]]</span>
     <div id="button">OK</div>
   </template>
   <script>
@@ -83,14 +83,12 @@
       behaviors: [PolymonElement],
 
       properties: {
-        notification: {
-          type: Object,
-          notify: true
+        message: {
+          type: String
         },
 
         type: {
           type: String,
-          computed: '__computeType(notification.type)',
           observer: '__typeChanged'
         }
       },
@@ -99,22 +97,18 @@
         'button.tap': '__onButtonTap'
       },
 
-      __computeType: function(type) {
-        return type;
-      },
-
       __typeChanged: function(type, oldType) {
         if (oldType != null) {
           this.classList.remove(oldType);
         }
-
         if (type != null) {
           this.classList.add(type);
         }
       },
 
       __onButtonTap: function() {
-        this.set('notification.acknowledged', true);
+        this.fire('acknowledged');
+        this.active = false;
       }
     })
   </script>

--- a/client/src/polymon-app/polymon-notification.html
+++ b/client/src/polymon-app/polymon-notification.html
@@ -108,7 +108,6 @@
 
       __onButtonTap: function() {
         this.fire('acknowledged');
-        this.active = false;
       }
     })
   </script>

--- a/client/src/polymon-app/polymon-qr-code-scanner.html
+++ b/client/src/polymon-app/polymon-qr-code-scanner.html
@@ -226,16 +226,7 @@
         if (uploadedImageUrl) {
           // Disable the camera while processing the image.
           this.stopScanning();
-
-          // Rotate the transform once to accomodate for Safari's
-          // dizzyingly awful tendency to rotate photos taken with the camera
-          // to "fix" user orientation.
-          const transform = new MeatScopeTransform();
-          this.__captureFromUploadedImage(transform)
-            .catch(() => {
-              transform.rotateRight();
-              return this.__captureFromUploadedImage(transform);
-            })
+          this.__captureFromUploadedImage()
             .catch(error => this.__showError('QR Code scan failed:', error))
             .then(() => {
               // Reset the fallback file input:
@@ -284,10 +275,12 @@
         this.$.media.active = true;
         // Wait a second, then check if can scan.
         this.debounce('scan', () => {
-          if (!this.stream || !this.$.media.active) {
+          if (!this.$.media.active) {
             return;
           }
-          this.__captureFromCamera()
+          // If we have a stream, capture, else we just wait for another second.
+          const capturePromise = this.stream ? this.__captureFromCamera() : Promise.resolve();
+          capturePromise
             .catch(error => this.__showError('QR Code scan failed:', error))
             .then(() => this.scan());
         }, 1000);
@@ -362,7 +355,7 @@
           .then(data => this.__saveQRCode(data));
       },
 
-      __captureFromUploadedImage: function(transform) {
+      __captureFromUploadedImage: function() {
         return new Promise((resolve, reject) => {
           let image = document.createElement('img');
           // NOTE(cdata): scale, x and y are here to trick the meat scope
@@ -379,7 +372,7 @@
                 image, 600, 0, 0, image.width, image.height);
 
             this.imagePreview
-                .draw(image, captureRect, transform);
+                .draw(image, captureRect, new MeatScopeTransform());
 
             try {
               resolve(this.__process(this.imagePreview, captureRect));
@@ -446,8 +439,8 @@
         console.log(title, error);
       },
 
-      __windowFocusChanged: function(e) {
-        if (e.type === 'focus') {
+      __windowFocusChanged: function(event) {
+        if (event.type === 'focus') {
           this.scan();
         } else {
           this.stopScanning();

--- a/client/src/polymon-app/polymon-qr-code-scanner.html
+++ b/client/src/polymon-app/polymon-qr-code-scanner.html
@@ -8,7 +8,7 @@
 <link rel="import" href="polymon-button.html">
 <link rel="import" href="polymon-spinner.html">
 <dom-module id="polymon-qr-code-scanner">
-  <template>
+  <template strip-whitespace>
     <style>
       :host {
         @apply --layout-fit;
@@ -150,7 +150,10 @@
       </a>
       <div id="upload-container">
         <polymon-button>Upload a QR Code Photo</polymon-button>
-        <input id="input" type="file" capture="camera" accept="image/*">
+        <!-- NOTE(valdrin) the `capture` attribute causes Android to directly
+         open the camera instead of asking the user to choose between camera or
+         the photo library -->
+        <input id="input" type="file" accept="image/*">
       </div>
     </section>
   </template>
@@ -436,7 +439,7 @@
 
       // TODO implement ui to show error to user
       __showError: function(title, error) {
-        console.log(title, error);
+        console.error(title, error);
       },
 
       __windowFocusChanged: function(event) {

--- a/client/src/polymon-app/polymon-qr-code-scanner.html
+++ b/client/src/polymon-app/polymon-qr-code-scanner.html
@@ -169,11 +169,6 @@
           notify: true
         },
 
-        scanning: {
-          type: Boolean,
-          value: false
-        },
-
         imagePreview: {
           type: Object,
           value: function() {

--- a/client/src/polymon-app/polymon-qr-code-scanner.html
+++ b/client/src/polymon-app/polymon-qr-code-scanner.html
@@ -90,7 +90,7 @@
         position: relative;
       }
 
-      #upload-container polymon-button {
+      #upload-container > * {
         width: 100%;
       }
 
@@ -223,12 +223,33 @@
             URL.revokeObjectURL(oldUploadedImageUrl);
           } catch (e) {}
         }
+        if (uploadedImageUrl) {
+          // Disable the camera while processing the image.
+          this.stopScanning();
+
+          // Rotate the transform once to accomodate for Safari's
+          // dizzyingly awful tendency to rotate photos taken with the camera
+          // to "fix" user orientation.
+          const transform = new MeatScopeTransform();
+          this.__captureFromUploadedImage(transform)
+            .catch(() => {
+              transform.rotateRight();
+              return this.__captureFromUploadedImage(transform);
+            })
+            .catch(error => this.__showError('QR Code scan failed:', error))
+            .then(() => {
+              // Reset the fallback file input:
+              this.$.input.value = null;
+              // Unset the uploaded image URL if one exists:
+              this._setUploadedImageUrl(null);
+              // Restart scanning.
+              this.scan();
+            });
+        }
       },
 
       __onInputChange: function() {
         let file = this.$.input.files[0];
-        let currentUpload = this.imageUpload || Promise.resolve();
-
         if (file != null) {
           this._setUploadedImageUrl(URL.createObjectURL(file));
         }
@@ -236,7 +257,6 @@
 
       get ownerHost() {
         let root = Polymer.dom(this).getOwnerRoot();
-
         return (root && root.host) || document;
       },
 
@@ -256,61 +276,34 @@
         this.unlisten(this.__ownerHost,
             'polymon-qr-code-scanner-activate', '__onActivateRequest');
         this.unlisten(this.__ownerHost,
-            'polymon-qr-code-scanner-deactivate', '__onDeactivateRequest')
+            'polymon-qr-code-scanner-deactivate', '__onDeactivateRequest');
         this.__ownerHost = null;
       },
 
       scan: function() {
-        let self = this;
         this.$.media.active = true;
-
-        (function doScan() {
-          if (!self.$.media.active) {
+        // Wait a second, then check if can scan.
+        this.debounce('scan', () => {
+          if (!this.stream || !this.$.media.active) {
             return;
           }
-
-          self.__scanForQrCode().then(data => {
-            let validData;
-
-            if (self.urlRe.test(data)) {
-              let [url, fragment] = data.match(self.originRe) || [];
-              validData = fragment;
-            } else if (self.polymonCodeRe.test(data)){
-              validData = data;
-            }
-
-            if (validData == null) {
-              console.log('Cannot use QR Code data:', data);
-              return;
-            }
-
-            console.log('Usable QR Code data:', validData);
-
-            let [type, code] = validData.split('.');
-
-            self._setCode({
-              type,
-              code,
-              continueTo: self.returnTo
-            });
-          }).catch(error => {
-            console.log('QR Code scan failed:', error);
-          }).then(() => {
-            setTimeout(doScan, 1000);
-          });
-        })();
+          this.__captureFromCamera()
+            .catch(error => this.__showError('QR Code scan failed:', error))
+            .then(() => this.scan());
+        }, 1000);
       },
 
       stopScanning: function() {
         console.log('STOP SCANNING');
+
+        // Stop any debouncer that might change `active`.
+        this.cancelDebouncer('activeChanged');
+        this.cancelDebouncer('scan');
+
         // Stop the media stream:
         this.$.media.active = false;
         // Clear the video src, blacking it out:
         this.$.video.$.video.src = null;
-        // Reset the fallback file input:
-        this.$.input.value = null;
-        // Unset the uploaded image URL if one exists:
-        this._setUploadedImageUrl(null);
         // Unset the scanned code if one exists:
         this._setCode(null);
       },
@@ -340,8 +333,12 @@
       __activeChanged: function() {
         this.debounce('activeChanged', () => {
           if (this.active) {
+            this.listen(window, 'focus', '__windowFocusChanged');
+            this.listen(window, 'blur', '__windowFocusChanged');
             this.scan();
           } else {
+            this.unlisten(window, 'focus', '__windowFocusChanged');
+            this.unlisten(window, 'blur', '__windowFocusChanged');
             this.stopScanning();
           }
         }, 300);
@@ -361,10 +358,11 @@
           } catch (e) {
             reject(e);
           }
-        });
+        })
+          .then(data => this.__saveQRCode(data));
       },
 
-      __captureFromUploadedImage: function() {
+      __captureFromUploadedImage: function(transform) {
         return new Promise((resolve, reject) => {
           let image = document.createElement('img');
           // NOTE(cdata): scale, x and y are here to trick the meat scope
@@ -376,45 +374,23 @@
           image.y = 0;
           image.crossOrigin = "Anonymous";
 
-          if (this.__transform == null) {
-            this.__transform = new MeatScopeTransform();
-          } else {
-            // Rotate the transform each time to accomodate for Safari's
-            // dizzyingly awful tendency to rotate photos taken with the camera
-            // to "fix" user orientation. Eventually we will get it right (but
-            // it might take a few tries):
-            this.__transform.rotateRight();
-          }
-
           image.onload = event => {
             let captureRect = new MeatScopeCaptureRect(
                 image, 600, 0, 0, image.width, image.height);
 
             this.imagePreview
-                .draw(image, captureRect, this.__transform);
+                .draw(image, captureRect, transform);
 
             try {
               resolve(this.__process(this.imagePreview, captureRect));
-              this.__transform = null;
             } catch (e) {
               reject(e);
             }
           };
 
           image.src = this.uploadedImageUrl;
-        });
-      },
-
-      __scanForQrCode: function() {
-        return new Promise((resolve, reject) => {
-          if (this.camera != null) {
-            resolve(this.__captureFromCamera());
-          } else if (this.uploadedImageUrl != null) {
-            resolve(this.__captureFromUploadedImage());
-          } else {
-            reject(new Error('No valid image data source available.'));
-          }
-        });
+        })
+        .then(data => this.__saveQRCode(data));
       },
 
       __process: function(imagePreview, captureRect) {
@@ -441,6 +417,42 @@
         });
       },
 
+      /**
+       * Parses and saves `data` into `code`, throws an error if `data` is
+       * not valid.
+       */
+      __saveQRCode: function(data) {
+        let validData;
+        if (this.urlRe.test(data)) {
+          const [url, fragment] = data.match(this.originRe) || [];
+          validData = fragment;
+        } else if (this.polymonCodeRe.test(data)){
+          validData = data;
+        }
+        if (validData) {
+          const [type, code] = validData.split('.');
+          this._setCode({
+            type,
+            code,
+            continueTo: this.returnTo
+          });
+        } else {
+          throw new Error('Cannot use QR Code data');
+        }
+      },
+
+      // TODO implement ui to show error to user
+      __showError: function(title, error) {
+        console.log(title, error);
+      },
+
+      __windowFocusChanged: function(e) {
+        if (e.type === 'focus') {
+          this.scan();
+        } else {
+          this.stopScanning();
+        }
+      },
 
 
       __cameraChanged: function(camera) {

--- a/client/src/polymon-app/polymon-qr-code-scanner.html
+++ b/client/src/polymon-app/polymon-qr-code-scanner.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../../bower_components/meat-scope-elements/meat-scope-devices.html">
 <link rel="import" href="../../bower_components/meat-scope-elements/meat-scope-user-media.html">
 <link rel="import" href="../../bower_components/meat-scope-elements/meat-scope-film-strip.html">
+<link rel="import" href="polymon-notification.html">
 <link rel="import" href="polymon-element.html">
 <link rel="import" href="polymon-button.html">
 <link rel="import" href="polymon-spinner.html">
@@ -156,6 +157,7 @@
         <input id="input" type="file" accept="image/*">
       </div>
     </section>
+    <polymon-notification id="notification" message="QR Code scan failed"></polymon-notification>
   </template>
   <script>
     Polymer({
@@ -203,7 +205,7 @@
           readOnly: true,
           value: null,
           observer: '__codeChanged'
-        },
+        }
       },
 
       observers: [
@@ -225,14 +227,17 @@
           // Disable the camera while processing the image.
           this.stopScanning();
           this.__captureFromUploadedImage()
-            .catch(error => this.__showError('QR Code scan failed:', error))
+            .catch(error => {
+              this.__showError(error);
+              // Restart scanning after 3 seconds to give time to read the
+              // notification.
+              this.async(this.scan, 3000);
+            })
             .then(() => {
               // Reset the fallback file input:
               this.$.input.value = null;
               // Unset the uploaded image URL if one exists:
               this._setUploadedImageUrl(null);
-              // Restart scanning.
-              this.scan();
             });
         }
       },
@@ -279,13 +284,14 @@
           // If we have a stream, capture, else we just wait for another second.
           const capturePromise = this.stream ? this.__captureFromCamera() : Promise.resolve();
           capturePromise
-            .catch(error => this.__showError('QR Code scan failed:', error))
+            .catch(error => this.__showError(error))
             .then(() => this.scan());
         }, 1000);
       },
 
       stopScanning: function() {
         console.log('STOP SCANNING');
+        this.$.notification.active = false;
 
         // Stop any debouncer that might change `active`.
         this.cancelDebouncer('activeChanged');
@@ -302,6 +308,7 @@
       __codeChanged: function(code) {
         if (code != null) {
           this.$.media.active = false;
+          this.$.notification.active = false;
           this.fire('polymon-code', code);
           this.classList.add('has-code');
         } else {
@@ -432,9 +439,9 @@
         }
       },
 
-      // TODO implement ui to show error to user
-      __showError: function(title, error) {
-        console.error(title, error);
+      __showError: function(error) {
+        this.$.notification.message = error.message || error;
+        this.$.notification.active = true;
       },
 
       __windowFocusChanged: function(event) {

--- a/client/src/polymon-app/polymon-qr-code-scanner.html
+++ b/client/src/polymon-app/polymon-qr-code-scanner.html
@@ -4,7 +4,6 @@
 <link rel="import" href="../../bower_components/meat-scope-elements/meat-scope-devices.html">
 <link rel="import" href="../../bower_components/meat-scope-elements/meat-scope-user-media.html">
 <link rel="import" href="../../bower_components/meat-scope-elements/meat-scope-film-strip.html">
-<link rel="import" href="polymon-notification.html">
 <link rel="import" href="polymon-element.html">
 <link rel="import" href="polymon-button.html">
 <link rel="import" href="polymon-spinner.html">
@@ -157,7 +156,6 @@
         <input id="input" type="file" accept="image/*">
       </div>
     </section>
-    <polymon-notification id="notification" message="QR Code scan failed"></polymon-notification>
   </template>
   <script>
     Polymer({
@@ -230,8 +228,8 @@
             .catch(error => {
               this.__showError(error);
               // Restart scanning after 3 seconds to give time to read the
-              // notification.
-              this.async(this.scan, 3000);
+              // notification. Re-use debouncer so it can be stopped after.
+              this.debounce('scan', this.scan, 3000);
             })
             .then(() => {
               // Reset the fallback file input:
@@ -291,11 +289,15 @@
 
       stopScanning: function() {
         console.log('STOP SCANNING');
-        this.$.notification.active = false;
 
         // Stop any debouncer that might change `active`.
         this.cancelDebouncer('activeChanged');
         this.cancelDebouncer('scan');
+
+        // Hide qr-code notification.
+        this.fire('polymon-hide-notification', {
+          notificationId: 'qr-code'
+        });
 
         // Stop the media stream:
         this.$.media.active = false;
@@ -308,7 +310,9 @@
       __codeChanged: function(code) {
         if (code != null) {
           this.$.media.active = false;
-          this.$.notification.active = false;
+          this.fire('polymon-hide-notification', {
+            notificationId: 'qr-code'
+          });
           this.fire('polymon-code', code);
           this.classList.add('has-code');
         } else {
@@ -440,8 +444,10 @@
       },
 
       __showError: function(error) {
-        this.$.notification.message = error.message || error;
-        this.$.notification.active = true;
+        this.fire('polymon-show-notification', {
+          notificationId: 'qr-code',
+          message: (error.message || error)
+        });
       },
 
       __windowFocusChanged: function(event) {


### PR DESCRIPTION
This PR separates the image uploading flow from the QR Code scanning flow.

We stop scanning for QR codes whenever possible, e.g.
- when user switches tabs
- the user is choosing the photo to upload
- we are processing the uploaded image

Also, we use `<polymon-notification>` to notify of scanning errors (modified the element to be more easy to use). This should fix https://github.com/PolymerElements/polymon/issues/64 as the user will have feedback when things don't work.

@cdata WDYT?