### PR TITLE
handle duplicate polymons

### DIFF
--- a/client/src/polymon-app/polymon-app.html
+++ b/client/src/polymon-app/polymon-app.html
@@ -370,17 +370,20 @@
           // the database. When a reference is scanned, we attempt to catch
           // the Polymon by pushing the details on to the user's catch queue.
           case 'reference':
-            let catchData = { code };
-
-            if (this.playerLatLng) {
-              catchData.latLng = this.playerLatLng;
-            }
-
-            let catchId = firebase.app('polymon').database()
-                .ref(`/users/${this.user.uid}/catchQueue`)
-                .push(catchData).key;
-
-            this.push('unconfirmedCatches', catchId);
+            this.__polydexEntryForCode(code).then(polydexEntry => {
+              if (polydexEntry) {
+                // Duplicate catch! Navigate to the caught page.
+                this.set('route.path', `/caught/${polydexEntry.polymonId}`);
+                return;
+              }
+              const catchData = { code };
+              if (this.playerLatLng) {
+                catchData.latLng = this.playerLatLng;
+              }
+              const catchId = firebase.app('polymon').database()
+                  .ref(`/users/${this.user.uid}/catchQueue`).push(catchData).key;
+              this.push('unconfirmedCatches', catchId);
+            });
             break;
           // A battle code is typically shared from one user to another when one
           // user starts a battle and the other user scans the code on her
@@ -401,6 +404,18 @@
             }
             break;
         }
+      },
+
+      __polydexEntryForCode: function(code) {
+        return firebase.app('polymon').database()
+          .ref(`/users/${this.user.uid}/catchQueue`).once('value')
+          .then(snapshot => snapshot.val())
+          .then(catchQueue => {
+            // Leverage local polydex to find the polydexEntry.
+            return this.polydex.find(function(polydexEntry) {
+              return catchQueue[polydexEntry.catchId].code === code;
+            });
+          });
       },
 
       __computePolydexPath: function(user) {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/polymon/issues/63, fixes #64 by sending a notification to the user when the polymon has already been caught.
We do the check both on the client & server side; if the client captures a duplicate catch, it will redirect to the caught polymon overlay. If the server catches the duplicate capture, it sends the notification to the user. 