### PR TITLE
Fix header colors for about / battle pages. Convert polydex stats list to `ul`.

### DIFF
--- a/client/src/polymon-app/polymon-detail.html
+++ b/client/src/polymon-app/polymon-detail.html
@@ -121,9 +121,16 @@
         margin-bottom: .25em;
       }
 
-      #stats > h2 {
+      #stats > ul {
+        font-size: 1.35em;
+        font-family: var(--polymon-accent-font-family);
+        margin: 0px;
+        padding: 0px;
+      }
+
+      #stats > ul li {
+        display: block;
         margin: 0 0 0.25em 0;
-        font-weight: normal;
       }
 
       #flavor {
@@ -204,9 +211,11 @@
       <section id="stats">
         <h1>[[__infoText(polymon.name, caught)]]</h1>
         <hr>
-        <h2>Attack <span class="slash">/</span> [[__infoText(polymon.stats.attack, caught)]]</h2>
-        <h2>Focus <span class="slash">/</span> [[__infoText(polymon.stats.focus, caught)]]</h2>
-        <h2>Counter <span class="slash">/</span> [[__infoText(polymon.stats.counter, caught)]]</h2>
+        <ul>
+          <li>Attack <span class="slash">/</span> [[__infoText(polymon.stats.attack, caught)]]</li>
+          <li>Focus <span class="slash">/</span> [[__infoText(polymon.stats.focus, caught)]]</li>
+          <li>Counter <span class="slash">/</span> [[__infoText(polymon.stats.counter, caught)]]</li>
+        </ul>
         <hr>
       </section>
       <section id="flavor">

--- a/client/src/polymon-app/polymon-styles.html
+++ b/client/src/polymon-app/polymon-styles.html
@@ -16,22 +16,20 @@
       }
 
       h1, h2, h3 {
+        color: #424242; /* Grey 800 */
         font-weight: normal;
         font-family: var(--polymon-accent-font-family);
       }
 
       h1 {
-        color: #424242; /* Grey 800 */
         font-size: 2em;
       }
 
       h2 {
-        color: #747474; /* Grey 600 */
         font-size: 1.35em;
       }
 
       h3 {
-        color: #424242; /* Grey 800 */
         font-size: 1.2em;
         margin: 0.4em 0px;
       }


### PR DESCRIPTION
This changes the polydex to `ul` + `li`s instead of `h2`s so that all headers can be the same again. (I forgot about the other `h2`s when we were talking about colors yesterday. :/ )

| before | after |
| - | - |
| ![screen shot 2017-05-04 at 13 17 24](https://cloud.githubusercontent.com/assets/406614/25723275/38f68b64-30cc-11e7-96de-e5ee7df42ac6.png) | ![screen shot 2017-05-04 at 13 17 43](https://cloud.githubusercontent.com/assets/406614/25723294/4b96eaca-30cc-11e7-85f9-d1e60b8be069.png) |
| ![screen shot 2017-05-04 at 13 18 24](https://cloud.githubusercontent.com/assets/406614/25723308/5552334e-30cc-11e7-83cc-5844b23e0e67.png) | ![screen shot 2017-05-04 at 13 18 04](https://cloud.githubusercontent.com/assets/406614/25723320/68878d10-30cc-11e7-8373-d9cfefcaf860.png) |
| | (no change) |



