### PR TITLE
Prevent underlines on the start screen in WebKit / Gecko.

### DIFF
--- a/client/src/polymon-app/polymon-start-screen.html
+++ b/client/src/polymon-app/polymon-start-screen.html
@@ -110,6 +110,10 @@
         @apply --layout-center-justified;
         width: 100%;
         margin: 0px 0.375rem;
+        /* This `text-decoration` is to prevent underlines in WebKit and Gecko,
+           which will extend over descendant inline-blocks if the anchor is
+           a flex container. */
+        text-decoration: none;
       }
 
       #options .row > a + a {


### PR DESCRIPTION
I messed this up when I added `display: flex;` to the links on the start page. Blink just doesn't put the underline there in the first place. I *think* Chrome is correct here but the spec is kinda poorly worded in this area.

| before | after |
| - | - |
| ![screen shot 2017-05-05 at 13 22 59](https://cloud.githubusercontent.com/assets/406614/25763053/3cca2956-3196-11e7-90e7-54dc153f02cc.png) | ![screen shot 2017-05-05 at 13 22 49](https://cloud.githubusercontent.com/assets/406614/25763069/50043ade-3196-11e7-88ad-5369488ced53.png) |
| ![screen shot 2017-05-05 at 13 23 06](https://cloud.githubusercontent.com/assets/406614/25763180/a6c0bdde-3196-11e7-95d8-88714769dd82.png) | ![screen shot 2017-05-05 at 13 22 36](https://cloud.githubusercontent.com/assets/406614/25763187/ba246542-3196-11e7-89b4-3c4e4876854b.png) |