### PR TITLE
Remove polymon-polydex's custom render function.

### DIFF
--- a/client/src/polymon-app/polymon-app.html
+++ b/client/src/polymon-app/polymon-app.html
@@ -287,7 +287,6 @@
             route="{{newBattleRoute}}"
             user="[[user]]">
         </polymon-new-battle-screen>
-        <div></div>
       </polymon-panel>
 
       <polymon-battle-screen
@@ -545,8 +544,8 @@
 
         const path = this.route.path;
         const pathParts = path.split('/');
-        let elementsToRender = this.$.multiPages.selectedValues;
-        let panelElementsToRender = this.$.panel.selectedValues;
+        let elementsToRender = [];
+        let panelElementsToRender = [];
 
         // controls what to render based on the path
         switch (pathParts.shift()) {

--- a/client/src/polymon-app/polymon-app.html
+++ b/client/src/polymon-app/polymon-app.html
@@ -544,8 +544,8 @@
 
         const path = this.route.path;
         const pathParts = path.split('/');
-        let elementsToRender = [];
-        let panelElementsToRender = [];
+        let elementsToRender = undefined;
+        let panelElementsToRender = undefined;
 
         // controls what to render based on the path
         switch (pathParts.shift()) {
@@ -599,8 +599,12 @@
             break;
         }
 
-        this.$.panel.selectedValues = panelElementsToRender;
-        this.$.multiPages.selectedValues = elementsToRender;
+        if (elementsToRender) {
+          this.$.multiPages.selectedValues = elementsToRender;
+        }
+        if (panelElementsToRender) {
+          this.$.panel.selectedValues = panelElementsToRender;
+        }
       }
     });
   </script>

--- a/client/src/polymon-app/polymon-multi-pages-behavior.html
+++ b/client/src/polymon-app/polymon-multi-pages-behavior.html
@@ -55,8 +55,8 @@
 
         if (renderFn) {
           element.render(shouldRender);
-        } else if(Polymer.isInstance(element)) {
-          console.error(`No render function for ${element.getAttribute('page-name')}`);
+        } else {
+          console.error(`No render function for ${pageName}`);
         }
       }
     };

--- a/client/src/polymon-app/polymon-new-battle-screen.html
+++ b/client/src/polymon-app/polymon-new-battle-screen.html
@@ -13,9 +13,8 @@
   <template>
     <style include="typography">
       :host {
-        position: relative;
+        @apply --layout-fit;
 
-        position: relative;
         box-sizing: border-box;
         padding: 8px;
 
@@ -26,7 +25,7 @@
         overflow: hidden;
       }
 
-      :host([hidden]) {
+      :host([hidden]) > * {
         display: none !important;
       }
 

--- a/client/src/polymon-app/polymon-panel.html
+++ b/client/src/polymon-app/polymon-panel.html
@@ -31,6 +31,7 @@
 
       #container ::content > * {
         flex: 0 0 100%;
+        position: relative;
       }
     </style>
     <section id="container">

--- a/client/src/polymon-app/polymon-polydex.html
+++ b/client/src/polymon-app/polymon-polydex.html
@@ -16,7 +16,8 @@
   <template>
     <style include="typography wiggle-animation scaled-rotate-animation">
       :host {
-        position: relative;
+        @apply --layout-fit;
+
         box-sizing: border-box;
         padding: 8px;
 
@@ -27,6 +28,7 @@
         overflow: hidden;
       }
 
+      :host([hidden]) > *,
       [hidden] {
         display: none !important;
       }
@@ -276,27 +278,6 @@
 
       listeners: {
         'cancel-team-swap.tap': '__onCancelTeamSwapTap'
-      },
-
-      render: function(shouldBeVisible=false, config) {
-        if (this.__hidingTimeout) {
-          this.cancelAsync(this.__hidingTimeout)
-          this.__hidingTimeout = null;
-        }
-
-        if (shouldBeVisible) {
-          this.$.team.removeAttribute('hidden');
-          this.$.index.removeAttribute('hidden');
-          this.$.controls.removeAttribute('hidden');
-          this.$.detail.removeAttribute('hidden');
-        } else {
-          this._hidingTimeout = this.async(() => {
-            this.$.team.setAttribute('hidden', true);
-            this.$.index.setAttribute('hidden', true);
-            this.$.controls.setAttribute('hidden', true);
-            this.$.detail.setAttribute('hidden', true);
-          }, this.hideDelay);
-        }
       },
 
       __onPolymonAnchorClick: function(event) {


### PR DESCRIPTION
It looked like polymer-polydex has a custom implementation of `render` because it needs to keep its box in the page when it's hidden to prevent the panel layout from getting messed up. This PR removes that custom render function by hiding the contents of the polydex (and new battle screen) using`:host([hidden]) > *` instead.