### PR TITLE
split long text for wrapping on detail screen

### DIFF
--- a/client/src/polymon-app/polymon-detail.html
+++ b/client/src/polymon-app/polymon-detail.html
@@ -353,7 +353,9 @@
           return '???';
         }
 
-        return text.replace(/[^\s]/g, '?');
+        // replace non-space to ? and split anything over 8 question marks
+        return text.replace(/[^\s]/g, '?')
+            .replace(/\?\?\?\?\?\?\?\?[^\s]*/g, '???? ????');
       }
     });
   </script>


### PR DESCRIPTION
fixes #133 

The text will now wrap for smaller screens as well.

| before | after |
| - | - |
| <img width="400px" src="https://cloud.githubusercontent.com/assets/5981958/26083687/1265636c-398c-11e7-97c4-207485c0830e.png"> | <img width="400px" src="https://cloud.githubusercontent.com/assets/5981958/26085439/295b1906-3999-11e7-96b6-6e636ce69c23.png"> |