### PR TITLE
Changes the no-camera screen style.

### DIFF
--- a/client/src/polymon-app/polymon-qr-code-scanner.html
+++ b/client/src/polymon-app/polymon-qr-code-scanner.html
@@ -80,17 +80,30 @@
       }
 
       #fallback .text {
+        @apply --layout-flex-none;
         @apply --layout-vertical;
         @apply --layout-center-center;
         box-sizing: border-box;
-        width: 70vmin;
-        height: 70vmin;
-        max-width: 320px;
-        max-height: 320px;
+        min-width: 200px;
+        min-height: 200px;
+        width: 65vmin;
+        height: 65vmin;
+        max-width: 300px;
+        max-height: 300px;
         border: 12px solid #536DFE; /* Indigo A200 */
         border-radius: 10000px;
         padding: 36px 24px;
-        transition: none;
+      }
+
+      @media (max-height: 320px), (max-width: 280px) {
+        #fallback .text {
+          font-size: 0.8em;
+          padding: 24px;
+          min-width: 175px;
+          min-height: 175px;
+          width: 55vmin;
+          height: 55vmin;
+        }
       }
 
       #code-scanned-indicator {


### PR DESCRIPTION
Fixes #119.

| before | after |
| - | - |
| ![screen shot 2017-05-15 at 20 26 33](https://cloud.githubusercontent.com/assets/406614/26088649/3de6dae0-39ad-11e7-85fd-7471e07a8b86.png) | ![screen shot 2017-05-15 at 20 25 29](https://cloud.githubusercontent.com/assets/406614/26088650/3f41bf2c-39ad-11e7-891b-ea7f4dc91ac8.png) |
| ![screen shot 2017-05-15 at 20 26 40](https://cloud.githubusercontent.com/assets/406614/26088652/4098ccee-39ad-11e7-9d6c-eaf6e4bad2c9.png) | ![screen shot 2017-05-15 at 20 25 37](https://cloud.githubusercontent.com/assets/406614/26088653/41e904f6-39ad-11e7-8823-e276293480e2.png) |
| | the back button color change applies to the camera screen also: |
| ![screen shot 2017-05-15 at 20 27 22](https://cloud.githubusercontent.com/assets/406614/26088654/435e039a-39ad-11e7-9b93-e4f043997a22.png) | ![screen shot 2017-05-15 at 20 27 45](https://cloud.githubusercontent.com/assets/406614/26088656/44dc7ecc-39ad-11e7-8dc0-c82dd7e6884a.png) |

The text and circle change size slightly depending on your screen size:

| iPhone 5 | iPhone 6 Plus |
| - | - |
| ![screen shot 2017-05-15 at 20 25 29](https://cloud.githubusercontent.com/assets/406614/26088735/b1b1241c-39ad-11e7-966c-9091d2e3ccba.png) | ![screen shot 2017-05-15 at 20 32 10](https://cloud.githubusercontent.com/assets/406614/26088738/b3e1b922-39ad-11e7-9221-aaa2a3f59651.png) |